### PR TITLE
ERROR: could not get unknown property 'compile' 오류 해결

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     implementation "com.facebook.react:react-native:+"
 }
 task copyDownloadableDepsToLibs(type: Copy) {
-    from configurations.compile
+    from configurations.implementation
     into 'libs'
 }


### PR DESCRIPTION
- could not get unknown property 'compile' for configuration container of type org.gradle.api.internal.artifacts.configurations.Default 오류 해결